### PR TITLE
Initial commit of support for reading the Canvas Quiz Submission Facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ Note if you are not running Matthews on localhost with the default port (9966) y
 `````
 -Dmatthews.baseurl=<your matthews base url> // e.g., -Dmatthews.baseurl=https://lrw.cloudlrs.com
 `````
+
+### Lombok
+This project uses [Project Lombok](https://projectlombok.org) for data entities.
+Maven builds without issue.
+If you use an IDE, you will want to [install a Lombbok plugin (or enable support)](https://projectlombok.org/download.html)
+

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
           <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-csv</artifactId>
+        </dependency>
 		<dependency>
 		    <groupId>commons-io</groupId>
 		    <artifactId>commons-io</artifactId>
@@ -74,6 +78,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.12</version>
+            <scope>provided</scope>
         </dependency>
 	</dependencies>
 

--- a/src/main/java/unicon/matthews/dataloader/canvas/CanvasDataLoader.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/CanvasDataLoader.java
@@ -14,14 +14,15 @@ import org.springframework.stereotype.Component;
 import unicon.matthews.dataloader.DataLoader;
 import unicon.matthews.dataloader.MatthewsClient;
 import unicon.matthews.dataloader.canvas.model.CanvasDataDump;
+import unicon.matthews.dataloader.canvas.model.CanvasQuizSubmissionFact;
 import unicon.matthews.dataloader.canvas.reader.ClassReader;
 import unicon.matthews.dataloader.canvas.reader.EnrollmentReader;
 import unicon.matthews.dataloader.canvas.reader.LineItemReader;
+import unicon.matthews.dataloader.canvas.reader.QuizSubmissionFactReader;
 import unicon.matthews.dataloader.canvas.reader.UserReader;
 import unicon.matthews.oneroster.Enrollment;
 import unicon.matthews.oneroster.LineItem;
 import unicon.matthews.oneroster.User;
-import unicon.matthews.oneroster.Class;
 
 import static unicon.matthews.dataloader.canvas.CanvasDataApiClient.Options;
 
@@ -49,6 +50,9 @@ public class CanvasDataLoader implements DataLoader {
       CanvasDataDump dump = canvasDataApiClient.getLatestDump(Options.NONE);
 
       // Dump passed to the processors below needs to have been downloaded, or they will fail.
+
+      QuizSubmissionFactReader quizSubmissionFactReader = new QuizSubmissionFactReader();
+      Collection<CanvasQuizSubmissionFact> quizSubmissionFacts = quizSubmissionFactReader.read(dump);
 
       Map<String, unicon.matthews.oneroster.Class> classMap = new HashMap<>();
       Map<String, User> userMap = new HashMap<>();

--- a/src/main/java/unicon/matthews/dataloader/canvas/model/CanvasQuizSubmissionFact.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/model/CanvasQuizSubmissionFact.java
@@ -1,0 +1,180 @@
+package unicon.matthews.dataloader.canvas.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import unicon.matthews.dataloader.canvas.util.NullableDoubleFieldDeserializer;
+import unicon.matthews.dataloader.canvas.util.NullableIntegerFieldDeserializer;
+import unicon.matthews.dataloader.canvas.util.NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Canvas data dump facts about quiz submissions. This applies to both the latest and historical quiz submission facts.
+ *
+ * <p>The only difference between quiz_submission_fact and quiz_submission_historical_fact entries is the label of
+ * one field which contains the same value (<em>Foreign key to the quiz submission dimension table</em>). Equivalent
+ * field names are:
+ * <ul>
+ *   <li>quiz_submission_id</li>
+ *   <li>quiz_submission_historical_id</li>
+ * </ul>
+ * </p>
+ * <p>The <code>@JsonPropertyOrder</code> designates the tab delimited field order for this artifact.</p>
+ * <p>For each attribute description, the sources are from the Fact Schema links below, unless otherwise cited.</p>
+  *
+ * @see <a href="https://portal.inshosteddata.com/docs#quiz_submission_fact">Canvas Quiz Submission Fact Schema</a>
+ * @see <a href="https://portal.inshosteddata.com/docs#quiz_submission_historical_fact">Canvas Quiz Submission Historical Fact Schema</a>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(suppressConstructorProperties = true)
+@JsonPropertyOrder({ "score", "kept_score", "date", "course_id", "enrollment_term_id", "course_account_id", "quiz_id",
+        "assignment_id", "user_id", "submission_id", "enrollment_rollup_id",
+        "quiz_submission_id_OR_quiz_submission_historical_id", "quiz_points_possible", "score_before_regrade",
+        "fudge_points", "total_attempts", "extra_attempts", "extra_time", "time_taken"})
+public class CanvasQuizSubmissionFact {
+
+    /**
+     * <blockquote>Denotes the score for this submission. Its value would be NULL when they are in the 'preview',
+     * 'untaken' OR 'settings_only' workflow states (since it is associated with quiz moderation events). Or its value
+     * should not be NULL when workflow state is either 'complete' or 'pending_review'. It defaults to NULL.
+     * </blockquote>
+     */
+    @JsonProperty("score")
+    @JsonDeserialize(using = NullableDoubleFieldDeserializer.class)
+    private Optional<Double> score;
+
+    /**
+     * <blockquote>For quizzes that allow multiple attempts, this is the actual score that will be associated with the
+     * user for this quiz. This score depends on the scoring policy we have for the submission in the quiz submission
+     * dimension table, the workflow state being 'completed' or 'pending_review' and the allowed attempts to be greater
+     * than 1. Its value can be NULL when not all these required conditions are met.</blockquote>
+     */
+    @JsonProperty("kept_score")
+    @JsonDeserialize(using = NullableDoubleFieldDeserializer.class)
+    private Optional<Double> keptScore;
+
+    /**
+     * <blockquote>Contains the same value as 'finished_at'. Provided to support backward compatibility with the
+     * existing table in production.</blockquote>
+     * <p>This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas
+     * documentation does not state that. The related <em>finished_at</em> field referred to in the description which
+     * is part of the <em>quiz_submission_dim</em> also does not specify it may be null.</p>
+     */
+    @JsonProperty("date")
+    @JsonDeserialize(using = NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+    private Optional<Instant> date;
+
+    /**
+     * <blockquote>Foreign key to the course this submission belongs to.</blockquote>
+     */
+    @JsonProperty("course_id")
+    private long courseId;
+
+    /**
+     * <blockquote>Foreign key to the enrollment term of the course this submission belongs to.</blockquote>
+     */
+    @JsonProperty("enrollment_term_id")
+    private long enrollmentTermId;
+
+    /**
+     * <blockquote>Foreign key to the account of the course this submission belongs to</blockquote>
+     */
+    @JsonProperty("course_account_id")
+    private long courseAccountId;
+
+    /**
+     * <blockquote>ID of the quiz the quiz submission represents. Foreign key to the quiz dimension table.</blockquote>
+     */
+    @JsonProperty("quiz_id")
+    private long quizId;
+
+    /**
+     * <blockquote>Foreign key to the assignment the quiz belongs to.</blockquote>
+     */
+    @JsonProperty("assignment_id")
+    private long assignmentId;
+
+    /**
+     * <blockquote>ID of the user (who is a student) who made the submission. Foreign key to the user dimension
+     * table.</blockquote>
+     */
+    @JsonProperty("user_id")
+    private long userId;
+
+    /**
+     * <blockquote>ID to the submission the quiz submission represents. Foreign key to the quiz submission dimension
+     * table.</blockquote>
+     */
+    @JsonProperty("submission_id")
+    private long submissionId;
+
+    /**
+     * <blockquote>Foreign key to the enrollment roll-up dimension table.</blockquote>
+     */
+    @JsonProperty("enrollment_rollup_id")
+    private long enrollmentRollupId;
+
+    /**
+     * This is the only field which differs in field name between the two artifact dumps. Same value, so they are mapped
+     * to one field.
+     * <blockquote>Foreign key to the quiz submission dimension table.</blockquote>
+     */
+    @JsonProperty("quiz_submission_id_OR_quiz_submission_historical_id")
+    private long quizSubmissionId;
+
+    /**
+     * <blockquote>Maximum points that can be scored in this quiz.</blockquote>
+     */
+    @JsonProperty("quiz_points_possible")
+    private double quizPointsPossible;
+
+    /**
+     * <blockquote>Original score of the quiz submission prior to any re-grading. It's NULL if the submission has never
+     * been regraded. Defaults to NULL.</blockquote>
+     */
+    @JsonProperty("score_before_regrade")
+    @JsonDeserialize(using = NullableDoubleFieldDeserializer.class)
+    private Optional<Double> scoreBeforeRegrade;
+
+    /**
+     * <blockquote>Number of points the quiz submission's score was fudged (changed) by. Values can be negative or
+     * positive. Defaults to 0.</blockquote>
+     */
+    @JsonProperty("fudge_points")
+    private double fudgePoints;
+
+    /**
+     * <blockquote>Denotes the total number of attempts made by the student for the quiz. Is valid only if the quiz
+     * allows multiple attempts.</blockquote>
+     */
+    @JsonProperty("total_attempts")
+    private int totalAttempts;
+
+    /**
+     * <blockquote>Number of times the student was allowed to re-take the quiz over the multiple-attempt
+     * limit.</blockquote>
+     */
+    @JsonProperty("extra_attempts")
+    private int extraAttempts;
+
+    /**
+     * <blockquote>Amount of extra time allowed for the quiz submission, in minutes</blockquote>
+     */
+    @JsonProperty("extra_time")
+    private int extraTimeInMinutes;
+
+    /**
+     * <blockquote>Time taken, in seconds, to finish the quiz.</blockquote>
+     * <p>This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas
+     * documentation does not state that.</p>
+     */
+    @JsonProperty("time_taken")
+    @JsonDeserialize(using = NullableIntegerFieldDeserializer.class)
+    private Optional<Integer> timeTakenInSeconds;
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/reader/QuizSubmissionFactReader.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/reader/QuizSubmissionFactReader.java
@@ -1,0 +1,61 @@
+package unicon.matthews.dataloader.canvas.reader;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvParser;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import unicon.matthews.dataloader.canvas.model.CanvasDataArtifact;
+import unicon.matthews.dataloader.canvas.model.CanvasDataDump;
+import unicon.matthews.dataloader.canvas.model.CanvasDataFile;
+import unicon.matthews.dataloader.canvas.model.CanvasQuizSubmissionFact;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+
+public class QuizSubmissionFactReader {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private static final List<String> ARTIFACTS = Arrays.asList(
+            "quiz_submission_fact",
+            "quiz_submission_historical_fact");
+
+    private CsvMapper tsvMapper;
+    private CsvSchema tsvSchema;
+
+    public QuizSubmissionFactReader() {
+        // To allow for unknown trailing fields, enable the IGNORE_TRAILING_UNMAPPABLE feature below
+        this.tsvMapper = new CsvMapper().configure(CsvParser.Feature.IGNORE_TRAILING_UNMAPPABLE, false);
+        this.tsvSchema = tsvMapper.schemaFor(CanvasQuizSubmissionFact.class).withColumnSeparator('\t');
+    }
+
+    public Collection<CanvasQuizSubmissionFact> read(CanvasDataDump dump) throws IOException {
+
+        Collection<CanvasQuizSubmissionFact> canvasQuizSubmissionFacts = new ArrayList<>();
+
+        List<CanvasDataArtifact> quizSubmissionArtifacts = dump.getArtifactsByTable().entrySet().stream().filter(
+                artifactEntry -> ARTIFACTS.contains(artifactEntry.getKey())).map(Map.Entry::getValue).collect(
+                Collectors.toList());
+
+        List<CanvasDataFile> quizSubmissionDataFiles = quizSubmissionArtifacts.stream().map(
+                CanvasDataArtifact::getFiles).flatMap(List::stream).collect(Collectors.toList());
+
+        for (CanvasDataFile dataFile : quizSubmissionDataFiles) {
+            MappingIterator<CanvasQuizSubmissionFact> iterator = tsvMapper.readerFor(
+                    CanvasQuizSubmissionFact.class).with(tsvSchema).readValues(new GZIPInputStream(
+                    new FileInputStream(dataFile.getDownloadPath().toFile())));
+            canvasQuizSubmissionFacts.addAll(iterator.readAll());
+        }
+
+        return canvasQuizSubmissionFacts;
+    }
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/util/CanvasDataFieldValueOptions.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/util/CanvasDataFieldValueOptions.java
@@ -1,0 +1,17 @@
+package unicon.matthews.dataloader.canvas.util;
+
+public enum CanvasDataFieldValueOptions {
+
+    NULL("\\N");
+
+    private final String fieldValue;
+
+    private CanvasDataFieldValueOptions(String fieldValue) {
+        this.fieldValue = fieldValue;
+    }
+
+    public String getFieldValue() {
+        return this.fieldValue;
+    }
+
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/util/EpochMillisecondsDeserializer.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/util/EpochMillisecondsDeserializer.java
@@ -17,8 +17,7 @@ import java.time.Instant;
  */
 public class EpochMillisecondsDeserializer extends JsonDeserializer<Instant> {
     @Override
-    public Instant deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException,
-            JsonProcessingException {
+    public Instant deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         return Instant.ofEpochMilli(Long.parseLong(jsonParser.getText()));
     }
 }

--- a/src/main/java/unicon/matthews/dataloader/canvas/util/IsoDateTimeWithOptionalFractionOfSecondDeserializer.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/util/IsoDateTimeWithOptionalFractionOfSecondDeserializer.java
@@ -1,0 +1,30 @@
+package unicon.matthews.dataloader.canvas.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Deserializes an ISO Date Time which may contain fractions of a second but no time zone, and converts it to an Instant
+ * based on UTC.
+ * <p>
+ * Similar to <a href="https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_LOCAL_TIME">DateTimeFormatter.ISO_LOCAL_TIME</a>.
+ * There is no standard for Date Time with fraction of second values (0-6 fraction digits after decimal).</p>
+ */
+public class IsoDateTimeWithOptionalFractionOfSecondDeserializer extends JsonDeserializer<Instant> {
+
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSSSSS]");
+
+    @Override
+    public Instant deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
+        return LocalDateTime.parse(parser.getText(), formatter).atZone(ZoneOffset.UTC).toInstant();
+    }
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/util/NullableDoubleFieldDeserializer.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/util/NullableDoubleFieldDeserializer.java
@@ -1,0 +1,30 @@
+package unicon.matthews.dataloader.canvas.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static unicon.matthews.dataloader.canvas.util.CanvasDataFieldValueOptions.NULL;
+
+/**
+ * Deserializes a field of field of type Double which may be NULL, which is represented as <em>\N</em> in the Canvas
+ * data dumps.
+ * <p>This deserializer returns an <code>Optional</code> to better designate that the field value is optional.</p>
+ */
+public class NullableDoubleFieldDeserializer extends JsonDeserializer<Optional<Double>> {
+
+    @Override
+    public Optional<Double> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+        String fieldValueText = jsonParser.getText();
+        Double fieldValue = null;
+        if (!NULL.getFieldValue().equalsIgnoreCase(fieldValueText)) {
+          fieldValue = Double.valueOf(fieldValueText);
+        }
+        return Optional.ofNullable(fieldValue);
+    }
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/util/NullableIntegerFieldDeserializer.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/util/NullableIntegerFieldDeserializer.java
@@ -1,0 +1,29 @@
+package unicon.matthews.dataloader.canvas.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static unicon.matthews.dataloader.canvas.util.CanvasDataFieldValueOptions.NULL;
+
+/**
+ * Deserializes a field of field of type <code>Integer</code> which may be NULL, which is represented as <em>\N</em> in
+ * the Canvas data dumps.
+ * <p>This deserializer returns an <code>Optional</code> to better designate that the field value is optional.</p>
+ */
+public class NullableIntegerFieldDeserializer extends JsonDeserializer<Optional<Integer>> {
+
+    @Override
+    public Optional<Integer> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+        String fieldValueText = jsonParser.getText();
+        Integer fieldValue = null;
+        if (!NULL.getFieldValue().equalsIgnoreCase(fieldValueText)) {
+          fieldValue = Integer.valueOf(fieldValueText);
+        }
+        return Optional.ofNullable(fieldValue);
+    }
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/util/NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/util/NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer.java
@@ -1,0 +1,38 @@
+package unicon.matthews.dataloader.canvas.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static unicon.matthews.dataloader.canvas.util.CanvasDataFieldValueOptions.NULL;
+
+/**
+ * Deserializes an optional ISO Date Time field which may contain fractions of a second but no time zone, and converts
+ * it to an Instant based on UTC. Delegates to the <code>IsoDateTimeWithOptionalFractionOfSecondDeserializer</code> for
+ * deserialization if the field is not null.
+ * <p>This deserializer returns an <code>Optional</code> to better designate that the field value is optional.</p>
+ * @see IsoDateTimeWithOptionalFractionOfSecondDeserializer
+ */
+public class NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer extends JsonDeserializer<Optional<Instant>>  {
+
+    private IsoDateTimeWithOptionalFractionOfSecondDeserializer delegatedDeserializer =
+            new IsoDateTimeWithOptionalFractionOfSecondDeserializer();
+
+    @Override
+    public Optional<Instant> deserialize(JsonParser parser, DeserializationContext deserializationContext)
+            throws IOException {
+        String fieldValueText = parser.getText();
+        Instant fieldValue = null;
+        if (!NULL.getFieldValue().equalsIgnoreCase(fieldValueText)) {
+            fieldValue = delegatedDeserializer.deserialize(parser, deserializationContext);
+        }
+        return Optional.ofNullable(fieldValue);
+    }
+}


### PR DESCRIPTION
This PR also contains the changes sent in PR#3, so you can just focus on reviewing commit 8d2a974 for this one.

Initial commit of support for reading the Canvas Quiz Submission Facts dump artifacts (both Current and Historical).

This solution leverages the robust (de-)serialization capabilities of Jackson
and its supporting libraries to read the tab delimited data dump files. It does
so by adding the jackson-dataformat-csv extension which supports changing the
delimiter from a comma to a tab.

To further simplify the implementation, Project Lombok has also been added to
handle generation of the boilerplate accessors, constructors and mutators, so
the new model type CanvasQuizSubmissionFact provides a very simple data
transfer object to represent all of the Quiz Submission Fact data.

As a result of adding Lombok, developers will need to enable or install
a plugin in IDEs to work effectively with the simplified model classes which
rely on auto-generated code. Maven builds without any changes required.
https://projectlombok.org/download.html

Simple and reusable JsonDeserializer extensions have been added to handle
common data deserialization requirements for the Canvas dump tabular data.