### PR TITLE
Refinement to the Canvas Data Loader request conversion process

### DIFF
--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasConversionService.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasConversionService.java
@@ -1,0 +1,45 @@
+package unicon.matthews.dataloader.canvas.io.converter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import unicon.matthews.caliper.Event;
+import unicon.matthews.dataloader.canvas.model.CanvasPageRequest;
+import unicon.matthews.dataloader.canvas.model.CanvasQuizSubmission;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class CanvasConversionService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Autowired
+    private List<Converter<CanvasPageRequest, Event>> pageRequestToEventConverters;
+
+    public List<Event> convertPageRequests(Collection<CanvasPageRequest> sourceItems) {
+
+        List<Event> events = new ArrayList<>();
+
+        for (CanvasPageRequest sourceItem : sourceItems) {
+
+            Optional<Converter<CanvasPageRequest, Event>> selectedConverter =
+                    pageRequestToEventConverters.stream().filter(converter -> converter.supports(sourceItem)).findFirst();
+
+            if (selectedConverter.isPresent()) {
+                events.add(selectedConverter.get().convert(sourceItem));
+                logger.debug("Page Request Conversion PROCESSED by converter {} : {}",
+                        selectedConverter.get().getClass().getSimpleName(), sourceItem.toString());
+            } else {
+                logger.debug("Page Request Conversion SKIP request with no matching converter: {}", sourceItem.toString());
+            }
+        }
+
+        return events;
+    }
+
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasPageRequestToLoginEventConverter.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasPageRequestToLoginEventConverter.java
@@ -1,0 +1,76 @@
+package unicon.matthews.dataloader.canvas.io.converter;
+
+import org.springframework.stereotype.Component;
+import unicon.matthews.caliper.Agent;
+import unicon.matthews.caliper.Entity;
+import unicon.matthews.caliper.Event;
+import unicon.matthews.caliper.Group;
+import unicon.matthews.caliper.Membership;
+import unicon.matthews.dataloader.canvas.model.CanvasPageRequest;
+import unicon.matthews.dataloader.util.Maps;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static unicon.matthews.dataloader.util.Maps.entry;
+
+/**
+ * Converts a <code>CanvasPageRequest</code> to an appropriate Matthews Caliper <code>Event</code> type for login
+ * events.
+ */
+@Component
+public class CanvasPageRequestToLoginEventConverter implements Converter<CanvasPageRequest, Event> {
+
+    @Override
+    public boolean supports(CanvasPageRequest source) {
+        return source.getWebApplicationController().equalsIgnoreCase("login") &&
+                source.getWebApplicationAction().equalsIgnoreCase("new");
+    }
+
+    public Event convert(CanvasPageRequest canvasPageRequest) {
+
+        Event event = new Event.Builder()
+                .withId(UUID.randomUUID().toString())
+                .withType("http://purl.imsglobal.org/caliper/v1/SessionEvent")
+                .withAgent(new Agent.Builder()
+                        .withId(String.valueOf(canvasPageRequest.getUserId().orElse(null)))
+                        .withType("http://purl.imsglobal.org/caliper/v1/Person")
+                        .withExtensions(Maps.ofEntries(
+                                entry("real_user_id", String.valueOf(canvasPageRequest.getRealUserId().orElse(null))),
+                                entry("user_login", "TBD - Where is this - OneRoster User data?"),
+                                entry("root_account_id", canvasPageRequest.getRootAccountId().toString()),
+                                entry("root_account_lti_guid", "TBD - Where is this?")))
+                        .build())
+                .withAction("http://purl.imsglobal.org/vocab/caliper/v1/action#LoggedIn")
+                .withObject(new Entity.Builder()
+                        .withId("HOSTNAME?")
+                        .withType("http://purl.imsglobal.org/caliper/v1/SoftwareApplication")
+                        .withExtensions(Maps.ofEntries(
+                                entry("redirect_url", "REDIRECT_URL?")))
+                        .build())
+                .withEventTime(LocalDateTime.ofInstant(canvasPageRequest.getTimestamp(), ZoneId.of("UTC")))
+                .withEdApp(new Agent.Builder()
+                        .withId("HOSTNAME?")
+                        .withType("http://purl.imsglobal.org/caliper/v1/SoftwareApplication")
+                        .build())
+                .withGroup(new Group.Builder()
+                        .withId(String.valueOf(canvasPageRequest.getCourseId().orElse(null)))
+                        .withType("http://purl.imsglobal.org/caliper/v1/CourseSection")
+                        .withExtensions(Maps.ofEntries(
+                                entry("context_type", "TBD")))
+                        .build())
+                .withMembership(new Membership.Builder()
+                        .withId("SOME_MEMBERSHIP_ID")
+                        .withType("http: //purl.imsglobal.org/caliper/v1/Membership")
+                        .withMember("TBD ?")
+                        .withOrganization("TBD ?")
+                        .withRoles(Arrays.asList("???"))
+                        .build())
+                .withFederatedSession(canvasPageRequest.getSessionId()) // Use FederatedSession because spec does not have a separate session field.
+                .build();
+
+        return event;
+    }
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasPageRequestToLoginEventConverter.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasPageRequestToLoginEventConverter.java
@@ -1,76 +1,119 @@
 package unicon.matthews.dataloader.canvas.io.converter;
 
 import org.springframework.stereotype.Component;
-import unicon.matthews.caliper.Agent;
-import unicon.matthews.caliper.Entity;
 import unicon.matthews.caliper.Event;
-import unicon.matthews.caliper.Group;
-import unicon.matthews.caliper.Membership;
+import unicon.matthews.dataloader.canvas.model.CanvasDataPseudonymDimension;
 import unicon.matthews.dataloader.canvas.model.CanvasPageRequest;
-import unicon.matthews.dataloader.util.Maps;
+import unicon.matthews.oneroster.Enrollment;
+import unicon.matthews.oneroster.User;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.UUID;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
-import static unicon.matthews.dataloader.util.Maps.entry;
+import static unicon.matthews.dataloader.canvas.io.converter.EventBuilderUtils.usingMembership;
+
+import static unicon.matthews.dataloader.canvas.io.converter.EventBuilderUtils.usingPersonType;
+import static unicon.matthews.dataloader.canvas.io.converter.EventBuilderUtils.usingCourseSectionGroup;
 
 /**
  * Converts a <code>CanvasPageRequest</code> to an appropriate Matthews Caliper <code>Event</code> type for login
  * events.
  */
 @Component
-public class CanvasPageRequestToLoginEventConverter implements Converter<CanvasPageRequest, Event> {
+public class CanvasPageRequestToLoginEventConverter implements Converter<CanvasPageRequest, Optional<Event>> {
 
     @Override
     public boolean supports(CanvasPageRequest source) {
-        return source.getWebApplicationController().equalsIgnoreCase("login") &&
-                source.getWebApplicationAction().equalsIgnoreCase("new");
+        return (source.getWebApplicationController().equalsIgnoreCase("login/canvas")) &&
+                (source.getWebApplicationAction().equalsIgnoreCase("new") ||
+                        source.getWebApplicationAction().equalsIgnoreCase("create")) &&
+                source.getHttpStatus().equals("200");
     }
 
-    public Event convert(CanvasPageRequest canvasPageRequest) {
+    @Override
+    public Optional<Event> convert(CanvasPageRequest request, SupportingEntities supportingEntities) {
 
-        Event event = new Event.Builder()
-                .withId(UUID.randomUUID().toString())
-                .withType("http://purl.imsglobal.org/caliper/v1/SessionEvent")
-                .withAgent(new Agent.Builder()
-                        .withId(String.valueOf(canvasPageRequest.getUserId().orElse(null)))
-                        .withType("http://purl.imsglobal.org/caliper/v1/Person")
-                        .withExtensions(Maps.ofEntries(
-                                entry("real_user_id", String.valueOf(canvasPageRequest.getRealUserId().orElse(null))),
-                                entry("user_login", "TBD - Where is this - OneRoster User data?"),
-                                entry("root_account_id", canvasPageRequest.getRootAccountId().toString()),
-                                entry("root_account_lti_guid", "TBD - Where is this?")))
-                        .build())
-                .withAction("http://purl.imsglobal.org/vocab/caliper/v1/action#LoggedIn")
-                .withObject(new Entity.Builder()
-                        .withId("HOSTNAME?")
-                        .withType("http://purl.imsglobal.org/caliper/v1/SoftwareApplication")
-                        .withExtensions(Maps.ofEntries(
-                                entry("redirect_url", "REDIRECT_URL?")))
-                        .build())
-                .withEventTime(LocalDateTime.ofInstant(canvasPageRequest.getTimestamp(), ZoneId.of("UTC")))
-                .withEdApp(new Agent.Builder()
-                        .withId("HOSTNAME?")
-                        .withType("http://purl.imsglobal.org/caliper/v1/SoftwareApplication")
-                        .build())
-                .withGroup(new Group.Builder()
-                        .withId(String.valueOf(canvasPageRequest.getCourseId().orElse(null)))
-                        .withType("http://purl.imsglobal.org/caliper/v1/CourseSection")
-                        .withExtensions(Maps.ofEntries(
-                                entry("context_type", "TBD")))
-                        .build())
-                .withMembership(new Membership.Builder()
-                        .withId("SOME_MEMBERSHIP_ID")
-                        .withType("http: //purl.imsglobal.org/caliper/v1/Membership")
-                        .withMember("TBD ?")
-                        .withOrganization("TBD ?")
-                        .withRoles(Arrays.asList("???"))
-                        .build())
-                .withFederatedSession(canvasPageRequest.getSessionId()) // Use FederatedSession because spec does not have a separate session field.
-                .build();
+        Optional<Event> result = null;
 
-        return event;
+        Optional<String> userId = getUserIdFromAnotherSessionRequest(request, supportingEntities);
+
+        if (!userId.isPresent()) {
+            result = Optional.empty();
+        } else {
+
+            User user = supportingEntities.getUsers().values().stream().filter(u -> u.getSourcedId().equalsIgnoreCase(
+                    userId.get())).findFirst().get();
+
+            CanvasDataPseudonymDimension pseudonym = supportingEntities.getPseudonymDimensions().stream().filter(
+                    p -> p.getUserId().toString().equalsIgnoreCase(userId.get())
+            ).findFirst().get();
+
+
+            String userLogin = pseudonym.getUniqueName();
+            String rootAccountId = request.getRootAccountId().toString();
+
+            LocalDateTime eventTime = LocalDateTime.ofInstant(request.getTimestamp(), ZoneId.of("UTC"));
+
+            Event event;
+            Enrollment enrollment = null;
+            if (request.getCourseId().isPresent()) {
+                String courseId = request.getCourseId().get().toString();
+                enrollment = supportingEntities.getEnrollments().values().stream().filter(
+                        e -> e.getKlass().getSourcedId().equalsIgnoreCase(courseId)).findFirst().get();
+
+                event = EventBuilderUtils.usingLoginEventType()
+                        .withEventTime(eventTime)
+                        .withAgent(usingPersonType(user, userId.get(), userLogin, rootAccountId).build())
+                        .withGroup(usingCourseSectionGroup(enrollment).build())
+                        .withMembership(usingMembership(enrollment).build())
+                        .withFederatedSession(request.getSessionId())
+                        .build();
+            } else { // Omit the optional group and membership info if we have no enrollment info
+                event = EventBuilderUtils.usingLoginEventType()
+                        .withEventTime(eventTime)
+                        .withAgent(usingPersonType(user, userId.get(), userLogin, rootAccountId).build())
+                        .withFederatedSession(request.getSessionId())
+                        .build();
+            }
+
+            result = Optional.of(event);
+        }
+
+        return result;
+    }
+
+    /**
+     * The Canvas page requests data does not provide the user ID for the login event. We cannot reliably use the
+     * homepage/dashboard request as that may occur far more frequently and skew login metrics, so instead we will
+     * scan for another request within the authenticated session which should contain the user ID. This is horribly
+     * inefficient, need to find another way.
+     *
+     * The users controller with the user_dashboard action sometimes appears to have a URL of /?login_success=1
+     * If that was consistent we could use it and avoid this, however, our small sample of data from 1/22/2017 shows
+     * only 2 with a dashboard call to url /?login_success=1, and they are the same user ID only 6 minutes apart.
+     * There are 13 unique sessions that day (some clearly anonymous), but at least 8 unique authenticated sessions
+     * between 4 different users, which implies there should be at least 8 successful login events. The requests
+     * data is not reliable as the Canvas docs disclaim, but that would be a real loss of information.
+     *
+     * @param canvasPageRequest
+     * @param supportingEntities
+     * @return an {@code Optional} String ID for the user id, if found, otherwise the optional will be empty.
+     */
+    private Optional<String> getUserIdFromAnotherSessionRequest(CanvasPageRequest canvasPageRequest,
+            SupportingEntities supportingEntities) {
+        List<CanvasPageRequest> otherRequestsInSession = supportingEntities.getPageRequests().stream().filter(request ->
+                canvasPageRequest.getSessionId().equalsIgnoreCase(request.getSessionId())
+                        && request.getUserId().isPresent()).collect(Collectors.toList());
+
+        Optional<String> userId = null;
+        if (otherRequestsInSession.isEmpty()) {
+            userId = Optional.empty();
+        } else {
+            userId = Optional.of(otherRequestsInSession.get(0).getUserId().get().toString());
+        }
+        return userId;
     }
 }

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasPageRequestToLogoutEventConverter.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasPageRequestToLogoutEventConverter.java
@@ -1,0 +1,72 @@
+package unicon.matthews.dataloader.canvas.io.converter;
+
+import org.springframework.stereotype.Component;
+import unicon.matthews.caliper.Agent;
+import unicon.matthews.caliper.Entity;
+import unicon.matthews.caliper.Event;
+import unicon.matthews.caliper.Group;
+import unicon.matthews.caliper.Membership;
+import unicon.matthews.dataloader.canvas.model.CanvasPageRequest;
+import unicon.matthews.dataloader.util.Maps;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import static unicon.matthews.dataloader.util.Maps.entry;
+
+/**
+ * Converts a <code>CanvasPageRequest</code> to an appropriate Matthews Caliper <code>Event</code> type for logout
+ * events.
+ */
+@Component
+public class CanvasPageRequestToLogoutEventConverter implements Converter<CanvasPageRequest, Event> {
+
+    @Override
+    public boolean supports(CanvasPageRequest source) {
+        return source.getWebApplicationController().equalsIgnoreCase("login") &&
+                source.getWebApplicationAction().equalsIgnoreCase("destroy");
+    }
+
+    public Event convert(CanvasPageRequest canvasPageRequest) {
+
+        Event event = new Event.Builder()
+                .withId(UUID.randomUUID().toString())
+                .withType("http://purl.imsglobal.org/caliper/v1/SessionEvent")
+                .withAgent(new Agent.Builder()
+                        .withId(canvasPageRequest.getUserId().get().toString())
+                        .withType("http://purl.imsglobal.org/caliper/v1/Person")
+                        .withExtensions(Maps.ofEntries(
+                                entry("real_user_id", String.valueOf(canvasPageRequest.getRealUserId().orElse(null))),
+                                entry("user_login", "TBD - Where is this?"),
+                                entry("root_account_id", canvasPageRequest.getRootAccountId().toString()),
+                                entry("root_account_lti_guid", "TBD - Where is this?")))
+                        .build())
+                .withAction("http://purl.imsglobal.org/vocab/caliper/v1/action#LoggedOut")
+                .withObject(new Entity.Builder()
+                        .withId("HOSTNAME?")
+                        .withType("http://purl.imsglobal.org/caliper/v1/SoftwareApplication")
+                        .withExtensions(Maps.ofEntries(
+                                entry("redirect_url", "REDIRECT_URL?")))
+                        .build())
+                .withEventTime(LocalDateTime.ofInstant(canvasPageRequest.getTimestamp(), ZoneId.of("UTC")))
+                .withEdApp(new Agent.Builder()
+                        .withId("HOSTNAME?")
+                        .withType("http://purl.imsglobal.org/caliper/v1/SoftwareApplication")
+                        .build())
+                .withGroup(new Group.Builder()
+                        .withId(String.valueOf(canvasPageRequest.getCourseId().orElse(null)))
+                        .withType("http://purl.imsglobal.org/caliper/v1/CourseSection")
+                        .withExtensions(Maps.ofEntries(
+                                entry("context_type", "TBD")))
+                        .build())
+                .withMembership(new Membership.Builder()
+                        .withId("FU")
+                        .withType("http: //purl.imsglobal.org/caliper/v1/Membership")
+                        .build())
+                .withFederatedSession(canvasPageRequest.getSessionId()) // Use FederatedSession because spec does not have a separate session field.
+                .build();
+
+        return event;
+    }
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/Converter.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/Converter.java
@@ -1,0 +1,16 @@
+package unicon.matthews.dataloader.canvas.io.converter;
+
+import unicon.matthews.caliper.Event;
+
+/**
+ * General interface for type converters. The Type parameters &lt;S, T &gt; will allow the converters to be type safe
+ * and allow them to be filtered by type for distinct use in the conversion service, futher filtered by the supports
+ * method.
+ */
+public interface Converter<S, T> {
+
+    boolean supports(S source);
+
+    T convert(S source);
+
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/Converter.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/Converter.java
@@ -4,13 +4,13 @@ import unicon.matthews.caliper.Event;
 
 /**
  * General interface for type converters. The Type parameters &lt;S, T &gt; will allow the converters to be type safe
- * and allow them to be filtered by type for distinct use in the conversion service, futher filtered by the supports
+ * and allow them to be grouped by type for distinct use in the conversion service, further filtered by the supports
  * method.
  */
 public interface Converter<S, T> {
 
     boolean supports(S source);
 
-    T convert(S source);
+    T convert(S source, SupportingEntities supportingEntities);
 
 }

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/EventBuilderUtils.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/EventBuilderUtils.java
@@ -1,0 +1,137 @@
+package unicon.matthews.dataloader.canvas.io.converter;
+
+import unicon.matthews.caliper.Agent;
+import unicon.matthews.caliper.Entity;
+import unicon.matthews.caliper.Event;
+import unicon.matthews.caliper.Group;
+import unicon.matthews.caliper.Membership;
+import unicon.matthews.dataloader.util.Maps;
+import unicon.matthews.oneroster.Enrollment;
+import unicon.matthews.oneroster.User;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import static unicon.matthews.dataloader.util.Maps.entry;
+
+/**
+ * Supporting class to augment the {@link unicon.matthews.caliper.Event.Builder} with some default options for key
+ * event types to eliminate a lot of duplication and distill the focus onto only the key variable data.
+ *
+ * <p>The vocabulary constants are an interim solution as we wait for IMS Caliper vocabulary constants to materialize.
+ * </p>
+ */
+public class EventBuilderUtils {
+
+    // Far from replicating the whole ontology tree (https://github.com/fullersr/caliper-ontology/blob/master/caliper.owl)
+    // we just want to get some key groupings for these entities that cover most of what we have or may need for Canvas
+    // use.
+    // Some discrepancies exist in Canvas mapping docs, so leveraging constants will help to insure the data loaded
+    // into Matthews is at least consistent to support analysis and not disjoint between different event types.
+    public static class CaliperV1Vocab {
+
+        public static class Actor {
+            public static final String PERSON = "http://purl.imsglobal.org/caliper/v1/lis/Person";
+            public static final String GROUP = "http://purl.imsglobal.org/caliper/v1/lis/Group";
+            public static final String SOFTWARE_APPLICATION = "http://purl.imsglobal.org/caliper/v1/SoftwareApplication";
+            public static final String ORGANIZATION = "http://purl.imsglobal.org/caliper/v1/w3c/Organization";
+        }
+
+        public static class Event {
+            public static final String SESSION_EVENT = "http://purl.imsglobal.org/caliper/v1/SessionEvent";
+            public static final String OUTCOME_EVENT = "http://purl.imsglobal.org/caliper/v1/OutcomeEvent";
+        }
+
+        public static class Action {
+            public static final String LOGGED_IN = "http://purl.imsglobal.org/vocab/caliper/v1/action#LoggedIn";
+            public static final String LOGGED_OUT = "http://purl.imsglobal.org/vocab/caliper/v1/action#LoggedOut";
+            public static final String TIMED_OUT = "http://purl.imsglobal.org/vocab/caliper/v1/action#TimedOut";
+            public static final String CREATED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Created";
+            public static final String VIEWED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Viewed";
+            public static final String SKIPPED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Skipped";
+            public static final String REVIEWED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Reviewed";
+            public static final String COMPLETED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Completed";
+            public static final String SUBMITTED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Submitted";
+            public static final String UPDATED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Updated";
+            public static final String ACCESSED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Accessed";
+            public static final String GRADED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Graded";
+            public static final String DELETED = "http://purl.imsglobal.org/vocab/caliper/v1/action#Deleted";
+        }
+
+        public static class Entity {
+            public static final String COLLECTION = "http://purl.imsglobal.org/caliper/v1/Collection";
+            public static final String MEMBERSHIP = "http://purl.imsglobal.org/caliper/v1/Membership";
+            public static final String ATTEMPT = "http://purl.imsglobal.org/caliper/v1/Attempt";
+            public static final String DIGITAL_RESOURCE = "http://purl.imsglobal.org/caliper/v1/DigitalResource";
+            public static final String ASSIGNABLE_DIGITAL_RESOURCE = "http://purl.imsglobal.org/caliper/v1/AssignableDigitalResource";
+            public static final String COURSE = "http://purl.imsglobal.org/caliper/v1/lis/Course";
+            public static final String COURSE_OFFERING = "http://purl.imsglobal.org/caliper/v1/lis/CourseOffering";
+            public static final String COURSE_SECTION = "http://purl.imsglobal.org/caliper/v1/lis/CourseSection";
+        }
+    }
+
+    public static Agent.Builder usingPersonType(User user, String realUserId, String userLogin, String rootAccountId) {
+        return new Agent.Builder()
+                .withType(CaliperV1Vocab.Actor.PERSON)
+                .withId(user.getSourcedId())
+                .withExtensions(Maps.ofEntries(
+                        entry("real_user_id", realUserId),
+                        entry("user_login", userLogin),
+                        entry("root_account_id", rootAccountId),
+                        entry("root_account_lti_guid", "TBD - Where is this?")));  // TODO - Find this data or omit
+    }
+
+    public static Entity.Builder usingAccountObject() {
+        return new Entity.Builder()
+                .withId("https://unicon.instructure.com")                 // TODO - Where can we pull this from dump, or will it have to be configurable?
+                .withType(CaliperV1Vocab.Actor.SOFTWARE_APPLICATION)      // Should Id actually be the root_account_id? If so, does it even make sense to have that extension with the person?
+                .withExtensions(Maps.ofEntries(
+                        entry("redirect_url", "REDIRECT_URL?")));         // Not sure of the usefulness of this?
+    }
+
+    public static Agent.Builder usingCanvasApplication() {
+        return new Agent.Builder()
+                .withId("https://canvas.instructure.com")
+                .withType(CaliperV1Vocab.Actor.SOFTWARE_APPLICATION);
+    }
+
+    public static Group.Builder usingCourseSectionGroup(Enrollment enrollment) {
+        return new Group.Builder()
+                .withType(CaliperV1Vocab.Entity.COURSE_SECTION)
+                .withId(enrollment.getKlass().getSourcedId())
+                .withExtensions(Maps.ofEntries(
+                        entry("context_type", enrollment.getKlass().getTitle())));  // TODO - optional and course title is likely wrong - but where do we find something else useful for it
+    }
+
+    public static Membership.Builder usingMembership(Enrollment enrollment) {
+        return new Membership.Builder()
+                .withId(enrollment.getSourcedId())
+                .withType(CaliperV1Vocab.Entity.MEMBERSHIP)
+                .withMember(enrollment.getUser().getUserId())              // TODO Redundant - This was intended for a member enrollment ID (if one exists) - perhaps we omit?
+                .withOrganization(enrollment.getKlass().getSourcedId())    // CourseSection
+                .withRoles(Arrays.asList(enrollment.getRole().name()));
+    }
+
+    public static Event.Builder usingBaseEvent() {
+        return new Event.Builder()
+                .withId(UUID.randomUUID().toString())
+                .withObject(usingAccountObject().build())
+                .withEdApp(usingCanvasApplication().build());
+    }
+
+    public static Event.Builder usingSessionEventType() {
+        return usingBaseEvent()
+                .withType(CaliperV1Vocab.Event.SESSION_EVENT);
+
+    }
+
+    public static Event.Builder usingLoginEventType() {
+        return usingSessionEventType()
+                .withAction(CaliperV1Vocab.Action.LOGGED_IN);
+    }
+
+    public static Event.Builder usingLogoutEventType() {
+        return usingSessionEventType()
+                .withAction(CaliperV1Vocab.Action.LOGGED_OUT);
+    }
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/SupportingEntities.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/SupportingEntities.java
@@ -1,0 +1,27 @@
+package unicon.matthews.dataloader.canvas.io.converter;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+import unicon.matthews.dataloader.canvas.model.CanvasDataPseudonymDimension;
+import unicon.matthews.dataloader.canvas.model.CanvasPageRequest;
+import unicon.matthews.oneroster.Class;
+import unicon.matthews.oneroster.Enrollment;
+import unicon.matthews.oneroster.LineItem;
+import unicon.matthews.oneroster.User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Data
+@Builder
+public class SupportingEntities {
+
+    Map<String, Class> classes;
+    Map<String, User> users;
+    Collection<CanvasDataPseudonymDimension> pseudonymDimensions;
+    Map<String, Enrollment> enrollments;
+    Map<String, LineItem> lineItems;
+    Collection<CanvasPageRequest> pageRequests;
+
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/model/CanvasDataPseudonymDimension.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/model/CanvasDataPseudonymDimension.java
@@ -1,0 +1,174 @@
+package unicon.matthews.dataloader.canvas.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import unicon.matthews.dataloader.canvas.io.deserialize.IsoDateTimeWithOptionalFractionOfSecondDeserializer;
+import unicon.matthews.dataloader.canvas.io.deserialize.NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer;
+import unicon.matthews.dataloader.canvas.io.deserialize.NullableLongFieldDeserializer;
+import unicon.matthews.dataloader.canvas.io.deserialize.ReadableCanvasDumpArtifact;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Canvas data dump user login pseudonym information.
+ *
+ * <p>The <code>@JsonPropertyOrder</code> designates the tab delimited field order for this artifact.</p>
+ *
+ * <p>For each attribute description, the sources are from the Pseudonym Dimension Schema links below, unless otherwise
+ * cited.</p>
+ *
+ * @see <a href="https://portal.inshosteddata.com/docs#pseudonym_dim">Canvas Pseudonym Dimension Schema</a>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(suppressConstructorProperties = true)
+@JsonPropertyOrder({ "id", "canvas_id", "user_id", "account_id", "workflow_state", "last_request_at", "last_login_at",
+        "current_login_at", "last_login_ip", "current_login_ip", "position", "created_at", "updated_at",
+        "password_auto_generated", "deleted_at", "sis_user_id", "unique_name", "integration_id",
+        "authentication_provider_id"})
+public class CanvasDataPseudonymDimension implements ReadableCanvasDumpArtifact<CanvasDataPseudonymDimension.Types> {
+
+    public enum Types {
+        pseudonym_dim
+    }
+
+    /**
+     * <blockquote>Unique surrogate id for the pseudonym.</blockquote>
+     */
+    @JsonProperty("id")
+    protected Long id;
+
+    /**
+     * <blockquote>Primary key for this pseudonym in the the Canvas database</blockquote>
+     */
+    @JsonProperty("canvas_id")
+    protected Long canvasId;
+
+    /**
+     * <blockquote>Id for the user associated with this pseudonym</blockquote>
+     */
+    @JsonProperty("user_id")
+    protected Long userId;
+
+    /**
+     * <blockquote>Id for the account associated with this pseudonym</blockquote>
+     */
+    @JsonProperty("account_id")
+    protected Long accountId;
+
+    /**
+     * <blockquote>Workflow status indicating that pseudonym is [deleted] or [active]</blockquote>
+     */
+    @JsonProperty("workflow_state")
+    protected String workflowState;
+
+    /**
+     * <blockquote>Timestamp of when the user last logged in with this pseudonym</blockquote>
+     * <p>This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas
+     * documentation does not state that.</p>
+     */
+    @JsonProperty("last_request_at")
+    @JsonDeserialize(using = NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+    protected Optional<Instant> lastRequestAt;
+
+    /**
+     * <blockquote>Timestamp of last time a user logged in with this pseudonym</blockquote>
+     * <p>This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas
+     * documentation does not state that.</p>
+     */
+    @JsonProperty("last_login_at")
+    @JsonDeserialize(using = NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+    protected Optional<Instant> lastLoginAt;
+
+    /**
+     * <blockquote>Timestamp of when the user logged in</blockquote>
+     * <p>This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas
+     * documentation does not state that.</p>
+     */
+    @JsonProperty("current_login_at")
+    @JsonDeserialize(using = NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+    protected Optional<Instant> currentLoginAt;
+
+    /**
+     * <blockquote>IP address recorded the last time a user logged in with this pseudonym</blockquote>
+     */
+    @JsonProperty("last_login_ip")
+    protected String lastLoginIp;
+
+    /**
+     * <blockquote>IP address of user's current/last login</blockquote>
+     */
+    @JsonProperty("current_login_ip")
+    protected String currentLoginIp;
+
+    /**
+     * <blockquote>Position of user's login credentials</blockquote>
+     */
+    @JsonProperty("position")
+    protected Integer position;
+
+    /**
+     * <blockquote>Timestamp when this pseudonym was created in Canvas</blockquote>
+     */
+    @JsonProperty("created_at")
+    @JsonDeserialize(using = IsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+    protected Instant createdAt;
+
+    /**
+     * <blockquote>Timestamp when this pseudonym was last updated in Canvas</blockquote>
+     */
+    @JsonProperty("updated_at")
+    @JsonDeserialize(using = IsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+    protected Instant updatedAt;
+
+    /**
+     * <blockquote>	True if the password has been auto-generated</blockquote>
+     */
+    @JsonProperty("password_auto_generated")
+    protected Boolean passwordAutoGenerated;
+
+    /**
+     * <blockquote>Timestamp when the pseudonym was deleted (NULL if the pseudonym is still active)</blockquote>
+     */
+    @JsonProperty("deleted_at")
+    @JsonDeserialize(using = NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+    protected Optional<Instant> deletedAt;
+
+    /**
+     * <blockquote>Correlated id for the record for this course in the SIS system (assuming SIS integration is
+     * configured</blockquote>
+     */
+    @JsonProperty("sis_user_id")
+    protected String sisUserId;
+
+    /**
+     * <blockquote>Actual login id for a given pseudonym/account</blockquote>
+     */
+    @JsonProperty("unique_name")
+    protected String uniqueName;
+
+    /**
+     * <blockquote>A secondary unique identifier useful for more complex SIS integrations. This identifier must not
+     * change for the user, and must be globally unique.</blockquote>
+     */
+    @JsonProperty("integration_id")
+    protected String integrationId;
+
+    /**
+     * <blockquote>The authentication provider this login is associated with. This can be the integer ID of the
+     * provider, or the type of the provider (in which case, it will find the first matching provider</blockquote>
+     * <p>This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas
+     * documentation does not state that.</p>
+     */
+    @JsonProperty("authentication_provider_id")
+    @JsonDeserialize(using = NullableLongFieldDeserializer.class)
+    protected Optional<Long> authenticationProviderId;
+}

--- a/src/main/java/unicon/matthews/dataloader/util/Maps.java
+++ b/src/main/java/unicon/matthews/dataloader/util/Maps.java
@@ -1,0 +1,58 @@
+package unicon.matthews.dataloader.util;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class for working with type safe Maps within fluent interfaces in a more seamless way. Derived from the blog
+ * post <a href="http://minborgsjavapot.blogspot.com/2014/12/java-8-initializing-maps-in-smartest-way.html">
+ * Java 8, Initializing Maps in the Smartest Way</a>
+ *
+ * <p>Statically import the {@link Maps#entry} method and use like this:
+ * <pre>{@code
+ * Map<String, String> map = Maps.ofEntries(
+ *     entry("key1", "value1"),
+ *     entry("key2", "value2"),
+ *     entry("key3", "value3"));
+ * }</pre>
+ * </p>
+ * <p></p>This is an interim step until we get the new convenience factory methods of the same name
+ * (<a href="http://download.java.net/java/jdk9/docs/api/java/util/Map.html#ofEntries-java.util.Map.Entry...-">Map.ofEntries</a>)
+ * being added in Java 9 Collections.
+ * </p>
+ *
+ * @author Brad Szabo (bszabo@unicon.net)
+ * @see <a href="http://minborgsjavapot.blogspot.com/2014/12/java-8-initializing-maps-in-smartest-way.html">Java 8, Initializing Maps in the Smartest Way</a>
+ * @see <a href="http://download.java.net/java/jdk9/docs/api/java/util/Map.html#ofEntries-java.util.Map.Entry...-">Map.ofEntries</a>
+ */
+public class Maps {
+
+    /**
+     * Helper method to provide a more fluent interface to in-line Map creation. Use in conjunction with {@link #entry}.
+     *
+     * @param entry varargs of Map.Entry for the Map entries
+     * @param <K> the output type of the key mapping function
+     * @param <V> the output type of the value mapping functio
+     * @return a type safe Map with the provided entries
+     */
+    public static <K, V> Map<K, V> ofEntries(final Entry<? extends K, ? extends V>... entry) {
+        return Arrays.asList(entry).stream().map(e -> e).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    }
+
+    /**
+     * Helper method to provide a more fluent interface to in-line Map.Entry creation.
+     *
+     * @param key key with which the specified value is to be associated
+     * @param value value to be associated with the specified key
+     * @param <K> the output type of the key mapping function
+     * @param <V> the output type of the value mapping function
+     * @return a type safe Map Entry with the provided key and value
+     */
+    public static <K, V> Entry<K, V> entry(final K key, final V value) {
+        return new AbstractMap.SimpleEntry<>(key, value);
+    }
+
+}


### PR DESCRIPTION
Refinement to the Canvas Data Loader request conversion process.

After processing only a couple event types, it was obvious that some
refactoring to eliminate redundancy would be beneficial as we
significantly expand on the number of request type events being processed.

As a result, I added EventBuilderUtils to provide a wrapper around the
Event builder, allowing us to isolate the common (and in many cases
still uncertain) attributes so they are not replicated all over the
place. This distills each event converter down to the specific
attributes that are variable to each.

Due to the need for user and enrollment data in each event, I created
SupportingEntities as a simple holder for all of the supporting data.

This commit also adds parsing of the Canvas Pseudonym dimension data
via CanvasDataPseudonymDimension. We need that to get the user login
(pseudonym).

As mentioned in the code comments, transforming login events to Caliper
is not as straightforward as expected, since each actual Canvas event
record representing a login does not include the authenticating user
data. This commit adds an inefficient but necessary approach of scanning
the requests for another request in the same session which does contain
the user ID, and pulling that to send with the login event to Matthews.

NOTE: This is a work in progress. Refinement is still needed to insure
we are getting all of the login and logout events loaded properly for
the provided dumps. It is known that some are being omitted and I am
working on resolving those issues.

This contains initial work on the Canvas Page Requests conversion to Caliper.

This converter approach allows us to fairly cleanly load converters into
groups by the Source and Target types, and further filter within each of those
groups by the supports method in each converter which can examine the Source
model.

The Maps class is a shim based loosely on Java 9 Map.ofEntries which is useful
in conjunction with the fluent builder code.
Example:
    Map<String, String> map = Maps.ofEntries(
       entry("key1", "value1"),
       entry("key2", "value2"),
       entry("key3", "value3"));

Maps allows for type safe Map usage within fluent interfaces in a more seamless
way. I derived it from the blog post
http://minborgsjavapot.blogspot.com/2014/12/java-8-initializing-maps-in-smartest-way.html
and enhanced what that blog suggested to make it even simpler to use inline.
This is an interim utility until we get the new convenience factory methods of the same name
coming in Java 9 Collections.
http://download.java.net/java/jdk9/docs/api/java/util/Map.html#ofEntries-java.util.Map.Entry..