### PR TITLE
LAQ-163 Implement the Transform of Canvas Discussion Forum Entry created to IMS Caliper.

### DIFF
--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasConversionService.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasConversionService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 import unicon.matthews.caliper.Event;
 import unicon.matthews.dataloader.canvas.model.CanvasAssignmentDimension;
 import unicon.matthews.dataloader.canvas.model.CanvasCourseSectionDimension;
+import unicon.matthews.dataloader.canvas.model.CanvasDiscussionForumEntryDimension;
+import unicon.matthews.dataloader.canvas.model.CanvasDiscussionForumEntryFact;
 import unicon.matthews.dataloader.canvas.model.CanvasEnrollmentDimension;
 import unicon.matthews.dataloader.canvas.model.CanvasPageRequest;
 import unicon.matthews.dataloader.canvas.model.CanvasQuizDimension;
@@ -27,7 +29,7 @@ public class CanvasConversionService {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Autowired
-    private List<Converter<CanvasPageRequest, Optional<Event>> >pageRequestToEventConverters;
+    private List<Converter<CanvasPageRequest, Optional<Event>>> pageRequestToEventConverters;
     
     @Autowired
     private CanvasClassConverter canvasClassConverter;
@@ -43,6 +45,9 @@ public class CanvasConversionService {
     
     @Autowired
     private CanvasQuizConverter canvasQuizConverter;
+
+    @Autowired
+    private CanvasDiscussionForumEntryToCaliperEventConverter canvasDiscussionForumEntryToCaliperEventConverter;
     
     public List<Event> convertPageRequests(Collection<CanvasPageRequest> sourceItems,
             SupportingEntities supportingEntities) {
@@ -168,6 +173,29 @@ public class CanvasConversionService {
       }
       
       return lineItems;
+    }
+
+    public List<Event> convertCanvasDiscussionForumEntries(Collection<CanvasDiscussionForumEntryFact> forumEntryFacts,
+            SupportingEntities supportingEntities) {
+        List<Event> events = new ArrayList<>();
+
+        Optional<Event> event = null;
+
+        for (CanvasDiscussionForumEntryFact sourceItem : forumEntryFacts) {
+
+            event = canvasDiscussionForumEntryToCaliperEventConverter.convert(sourceItem, supportingEntities);
+
+            if (event.isPresent()) {
+                events.add(event.get());
+                logger.debug("Canvas Discussion Forum Entry Fact Conversion PROCESSED: From {} > EVENT: {}",
+                        sourceItem.toString(), event.get().toString());
+            } else {
+                logger.debug("Canvas Discussion Forum Entry Fact Conversion PROCESSED: From {} > NO EVENT",
+                        sourceItem.toString());
+            }
+        }
+
+        return events;
     }
 
 }

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasDiscussionForumEntryToCaliperEventConverter.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/CanvasDiscussionForumEntryToCaliperEventConverter.java
@@ -1,0 +1,102 @@
+package unicon.matthews.dataloader.canvas.io.converter;
+
+import org.springframework.stereotype.Component;
+import unicon.matthews.caliper.Entity;
+import unicon.matthews.caliper.Event;
+import unicon.matthews.dataloader.canvas.model.CanvasDataPseudonymDimension;
+import unicon.matthews.dataloader.canvas.model.CanvasDiscussionForumEntryDimension;
+import unicon.matthews.dataloader.canvas.model.CanvasDiscussionForumEntryFact;
+import unicon.matthews.dataloader.canvas.model.CanvasUserDimension;
+import unicon.matthews.oneroster.Enrollment;
+import unicon.matthews.oneroster.User;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static unicon.matthews.dataloader.canvas.io.converter.EventBuilderUtils.usingCourseSectionGroup;
+import static unicon.matthews.dataloader.canvas.io.converter.EventBuilderUtils.usingMembership;
+import static unicon.matthews.dataloader.canvas.io.converter.EventBuilderUtils.usingPersonType;
+
+/**
+ * Converts a <code>CanvasDiscussionForumEntryFact</code> and its related <code>CanvasDiscussionForumEntryDimension</code>
+ * to an appropriate Matthews Caliper <code>Event</code> type for forum entry events.
+ */
+@Component
+public class CanvasDiscussionForumEntryToCaliperEventConverter implements Converter<CanvasDiscussionForumEntryFact, Optional<Event>> {
+
+    @Override
+    public boolean supports(CanvasDiscussionForumEntryFact source) {
+        return true;
+    }
+
+    private static final String CANVAS_ACTIVE_STATE = "active";
+    private static final String CANVAS_DELETED_STATE = "deleted";
+
+    @Override
+    public Optional<Event> convert(CanvasDiscussionForumEntryFact discussionForumEntryFact,
+            SupportingEntities supportingEntities) {
+
+        Optional<Event> result = null;
+
+        CanvasDiscussionForumEntryDimension discussionForumEntryDimension =
+                supportingEntities.getDiscussionForumEntryDimensions().stream().filter(
+                        dim -> discussionForumEntryFact.getDiscussionEntryId().equals(dim.getId())).findFirst().get();
+
+        User user = supportingEntities.getUsers().get(discussionForumEntryFact.getUserId().toString());
+
+        CanvasUserDimension canvasUserDimension = supportingEntities.getCanvasUserDimensions().stream().filter(
+                u -> u.getId().equalsIgnoreCase(discussionForumEntryFact.getUserId().toString())).findFirst().get();
+
+        // Doing a lookup by user ID does not guarantee the actual pseudonym used for that login, it is only
+        // guaranteed if they only have one
+        Optional<CanvasDataPseudonymDimension> pseudonym = supportingEntities.getPseudonymDimensions().stream().filter(
+                p -> p.getUserId().toString().equalsIgnoreCase(user.getSourcedId())
+        ).findFirst();
+
+        String userLogin = pseudonym.isPresent() ? pseudonym.get().getUniqueName() : "Unknown Login";
+
+        LocalDateTime eventTime = LocalDateTime.ofInstant(discussionForumEntryDimension.getCreatedAt(), ZoneId.of("UTC"));
+
+        Enrollment enrollment = supportingEntities.getEnrollments().values().stream().filter(
+                    e -> e.getKlass().getSourcedId().equalsIgnoreCase(
+                            discussionForumEntryFact.getCourseId().toString())).findFirst().get();
+
+        Event event = EventBuilderUtils.usingMessageEventType()
+                .withAction(EventBuilderUtils.CaliperV1p1Vocab.Action.POSTED)
+                .withEventTime(eventTime)
+                .withAgent(usingPersonType(user, user.getUserId(), userLogin,
+                        canvasUserDimension.getRootAccountId().get().toString()).build())
+                .withObject(new Entity.Builder()
+                        .withId(discussionForumEntryDimension.getId().toString())
+                        .withType(EventBuilderUtils.CaliperV1p1Vocab.Entity.MESSAGE)
+                        .withIsPartOf(new Entity.Builder()
+                                .withId(discussionForumEntryFact.getTopicId().toString())
+                                .withType(EventBuilderUtils.CaliperV1p1Vocab.Entity.THREAD)
+                                .withIsPartOf(new Entity.Builder()
+                                        .withId("TBD - Forum ID?")
+                                        .withType(EventBuilderUtils.CaliperV1p1Vocab.Entity.FORUM)
+                                        .build())
+                                .build())
+                        .withDateCreated(eventTime)
+                        // TODO Activity Mapping has isReplyTo section, but that is not in spec anywhere (even 1.1)
+                        // Also has note "If Message is not a reply, then replyTo property is NULL."
+                        // https://github.com/IMSGlobal/caliper-spec/blob/master/caliper.md#forumProfile
+                        // replyTo is part of spec, and would need to be added to Matthews Event API.
+                        .build())
+                .withGroup(usingCourseSectionGroup(enrollment).build())
+                .withMembership(usingMembership(enrollment).build())
+                .withFederatedSession("TBD - correlate with request data")
+                .build();
+
+        // if (CANVAS_DELETED_STATE.equalsIgnoreCase(discussionForumEntryFact.getWorkflowState())) {
+            // If deleted, should we capture and send deleted events too?
+            // TODO - This is an instance of a one to many mapping of dimension/fact to multiple events.
+            // eventTime = LocalDateTime.ofInstant(discussionForumEntryFact.getDeletedAt().get(), ZoneId.of("UTC"));
+        // }
+
+        result = Optional.of(event);
+
+        return result;
+    }
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/EventBuilderUtils.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/EventBuilderUtils.java
@@ -28,7 +28,10 @@ public class EventBuilderUtils {
     // use.
     // Some discrepancies exist in Canvas mapping docs, so leveraging constants will help to insure the data loaded
     // into Matthews is at least consistent to support analysis and not disjoint between different event types.
-    public static class CaliperV1Vocab {
+    // https://github.com/IMSGlobal/caliper-contexts-public/blob/public/v1/Context.json
+    public static class CaliperV1p0Vocab {
+
+        public static final String CONTEXT = "http://purl.imsglobal.org/ctx/caliper/v1/Context";
 
         public static class Actor {
             public static final String PERSON = "http://purl.imsglobal.org/caliper/v1/lis/Person";
@@ -64,15 +67,170 @@ public class EventBuilderUtils {
             public static final String ATTEMPT = "http://purl.imsglobal.org/caliper/v1/Attempt";
             public static final String DIGITAL_RESOURCE = "http://purl.imsglobal.org/caliper/v1/DigitalResource";
             public static final String ASSIGNABLE_DIGITAL_RESOURCE = "http://purl.imsglobal.org/caliper/v1/AssignableDigitalResource";
+            public static final String MESSAGE = "http://purl.imsglobal.org/caliper/v1/Message";
             public static final String COURSE = "http://purl.imsglobal.org/caliper/v1/lis/Course";
             public static final String COURSE_OFFERING = "http://purl.imsglobal.org/caliper/v1/lis/CourseOffering";
             public static final String COURSE_SECTION = "http://purl.imsglobal.org/caliper/v1/lis/CourseSection";
         }
     }
 
+    /**
+     * https://github.com/IMSGlobal/caliper-spec/blob/master/caliper.md
+     *
+     * This is a more comprehensive list of Caliper the current 1.1 spec (minus roles at this time)
+     *
+     * Use of JSON-LD @context along with relative IRIs for Caliper 1.1 types allow them to be shortened in all examples
+     * in the 1.1 spec and explicit versions (v1) have been removed (see https://github.com/IMSGlobal/caliper-spec/issues/70)
+     * since it is now provided solely by the context version and was really redundant in v1.
+     * See the context definition at http://purl.imsglobal.org/ctx/caliper/v1p1 for the expanded IRIs  for
+     * actors/entities/objects, verbs/actions and events.
+     **/
+    public static class CaliperV1p1Vocab {
+
+        public static final String CONTEXT = "http://purl.imsglobal.org/ctx/caliper/v1p1";
+
+        public static class Entity {
+            public static final String ENTITY = "Entity";
+            public static final String AGENT = "Agent";
+            public static final String ANNOTATION = "Annotation";
+            public static final String ASSESSMENT = "Assessment";
+            public static final String ASSESSMENT_ITEM = "AssessmentItem";
+            public static final String ASSIGNABLE_DIGITAL_RESOURCE = "AssignableDigitalResource";
+            public static final String ATTEMPT = "Attempt";
+            public static final String AUDIO_OBJECT = "AudioObject";
+            public static final String BOOKMARK_ANNOTATION = "BookmarkAnnotation";
+            public static final String CHAPTER = "Chapter";
+            // Standalone /v1/lis/Course entity has been dropped in v1.1 (offering and section already existed)
+            public static final String COURSE_OFFERING = "CourseOffering"; // dropped lis in v1.1
+            public static final String COURSE_SECTION = "CourseSection"; // dropped lis in v1.1
+            public static final String DIGITAL_RESOURCE = "DigitalResource";
+            // Renamed from Collection to DigitalResourceCollection in v1.1
+            public static final String DIGITAL_RESOURCE_COLLECTION = "DigitalResourceCollection";
+            public static final String DOCUMENT = "Document";
+            public static final String FILL_IN_BLANK_RESPONSE = "FillinBlankResponse";
+            public static final String FORUM = "Forum";
+            public static final String FRAME = "Frame";
+            public static final String GROUP = "Group";
+            public static final String HIGHLIGHT_ANNOTATION = "HighlightAnnotation";
+            public static final String IMAGE_OBJECT = "ImageObject";
+            public static final String LEARNING_OBJECTIVE = "LearningObjective";
+            public static final String LTI_LESSON = "LtiSession";
+            public static final String MEDIA_LOCATION = "MediaLocation";
+            public static final String MEDIA_OBJECT = "MediaObject";
+            public static final String MEMBERSHIP = "Membership";
+            public static final String MESSAGE = "Message";
+            public static final String MULTIPLE_CHOICE_RESPONSE = "MultipleChoiceResponse";
+            public static final String MULTIPLE_RESPONSE_RESPONSE = "MultipleResponseResponse";
+            public static final String ORGANIZATION = "Organization";
+            public static final String PAGE = "Page";
+            public static final String PERSON = "Person";
+            public static final String RESPONSE = "Response";
+            public static final String RESULT = "Result";
+            public static final String SELECTOR = "Selector";
+            public static final String SELECT_TEXT_RESPONSE = "SelectTextResponse";
+            public static final String SESSION = "Session";
+            public static final String SHARED_ANNOTATION = "SharedAnnotation";
+            public static final String SOFTWARE_APPLICATION = "SoftwareApplication";
+            public static final String TAG_ANNOTATION = "TagAnnotation";
+            public static final String TEXT_POSITION_SELECTOR = "TextPositionSelector";
+            public static final String THREAD = "Thread";
+            public static final String TRUE_FALSE_RESPONSE = "TrueFalseResponse";
+            public static final String VIDEO_OBJECT =  "VideoObject";
+            public static final String WEB_PAGE = "WebPage";
+        }
+
+        public static class Event {
+            public static final String ANNOTATION_EVENT = "AnnotationEvent";
+            public static final String ASSESSMENT_EVENT = "AssessmentEvent";
+            public static final String ASSESSMENT_ITEM_EVENT = "AssessmentItemEvent";
+            public static final String ASSIGNABLE_EVENT = "AssignableEvent";
+            public static final String FORUM_EVENT = "ForumEvent";
+            public static final String MEDIA_EVENT = "MediaEvent";
+            public static final String MESSAGE_EVENT = "MessageEvent";
+            public static final String NAVIGATION_EVENT = "NavigationEvent";
+            public static final String OUTCOME_EVENT = "OutcomeEvent";
+            public static final String READING_EVENT = "ReadingEvent";
+            public static final String SESSION_EVENT = "SessionEvent";
+            public static final String THREAD_EVENT =  "ThreadEvent";
+            public static final String TOOL_USE__EVENT = "ToolUseEvent";
+            public static final String VIEW_EVENT = "ViewEvent";
+        }
+
+        // Action/Verbs also dropped v1 from the IRI properly in favor of only having that in the @context
+        // Shortened to relative IRIs composed of the verb: prefix and named aliases
+        // "verb": "http://purl.imsglobal.org/vocab/caliper/action#"
+        public static class Action {
+            public static final String ABANDONED = "Abandoned";
+            // Caliper v1.1. dropped the Accessed action/verb
+            public static final String ACTIVATED = "Activated";
+            public static final String ADDED = "Added";
+            public static final String ATTACHED = "Attached";
+            public static final String BOOKMARKED = "Bookmarked";
+            public static final String CHANGED_RESOLUTION = "ChangedResolution";
+            public static final String CHANGED_SIZE = "ChangedSize";
+            public static final String CHANGED_SPEED = "ChangedSpeed";
+            public static final String CHANGED_VOLUME = "ChangedVolume";
+            public static final String CLASSIFIED = "Classified";
+            public static final String CLOSED_POPOUT = "ClosedPopout";
+            public static final String COMMENTED = "Commented";
+            public static final String COMPLETED = "Completed";
+            public static final String CREATED = "Created";
+            public static final String DEACTIVATED = "Deactivated";
+            public static final String DELETED = "Deleted";
+            public static final String DESCRIBED = "Described";
+            public static final String DISABLED_CLOSE_CAPTIONING = "DisabledCloseCaptioning";
+            public static final String DISLIKED = "Disliked";
+            public static final String ENABLED_CLOSE_CAPTIONING = "EnabledCloseCaptioning";
+            public static final String ENDED = "Ended";
+            public static final String ENTERED_FULL_SCREEN = "EnteredFullScreen";
+            public static final String EXITED_FULL_SCREEN = "ExitedFullScreen";
+            public static final String FORWARDED_TO = "ForwardedTo";
+            public static final String GRADED = "Graded";
+            public static final String HID = "Hid";
+            public static final String HIGHLIGHTED = "Highlighted";
+            public static final String IDENTIFIED = "Identified";
+            public static final String JUMPED_TO = "JumpedTo";
+            public static final String LIKED = "Liked";
+            public static final String LINKED = "Linked";
+            public static final String LOGGED_IN = "LoggedIn";
+            public static final String LOGGED_OUT = "LoggedOut";
+            public static final String MARKED_AS_READ = "MarkedAsRead";
+            public static final String MARKED_AS_UNREAD = "MarkedAsUnread";
+            public static final String MODIFIED = "Modified";
+            public static final String MUTED = "Muted";
+            public static final String NAVIGATEDTO = "NavigatedTo";
+            public static final String OPENEDPOPOUT = "OpenedPopout";
+            public static final String PAUSED = "Paused";
+            public static final String POSTED = "Posted";
+            public static final String QUESTIONED = "Questioned";
+            public static final String RANKED = "Ranked";
+            public static final String RECOMMENDED = "Recommended";
+            public static final String REMOVED = "Removed";
+            public static final String RESET = "Reset";
+            public static final String RESTARTED = "Restarted";
+            public static final String RESUMED = "Resumed";
+            public static final String RETRIEVED = "Retrieved";
+            public static final String REVIEWED = "Reviewed";
+            public static final String REWOUND = "Rewound";
+            public static final String SEARCHED = "Searched";
+            public static final String SHARED = "Shared";
+            public static final String SHOWED = "Showed";
+            public static final String SKIPPED = "Skipped";
+            public static final String STARTED = "Started";
+            public static final String SUBMITTED = "Submitted";
+            public static final String SUBSCRIBED = "Subscribed";
+            public static final String TAGGED = "Tagged";
+            public static final String TIMED_OUT = "TimedOut";
+            public static final String UNMUTED = "Unmuted";
+            public static final String UNSUBSCRIBED = "Unsubscribed";
+            public static final String USED = "Used";
+            public static final String VIEWED = "Viewed";
+        }
+    }
+
     public static Agent.Builder usingPersonType(User user, String realUserId, String userLogin, String rootAccountId) {
         return new Agent.Builder()
-                .withType(CaliperV1Vocab.Actor.PERSON)
+                .withType(CaliperV1p1Vocab.Entity.PERSON)
                 .withId(user.getSourcedId())
                 .withExtensions(Maps.ofEntries(
                         entry("real_user_id", realUserId),
@@ -84,7 +242,7 @@ public class EventBuilderUtils {
     public static Entity.Builder usingAccountObject() {
         return new Entity.Builder()
                 .withId("https://unicon.instructure.com")                 // TODO - Where can we pull this from dump, or will it have to be configurable?
-                .withType(CaliperV1Vocab.Actor.SOFTWARE_APPLICATION)      // Should Id actually be the root_account_id? If so, does it even make sense to have that extension with the person?
+                .withType(CaliperV1p1Vocab.Entity.SOFTWARE_APPLICATION)      // Should Id actually be the root_account_id? If so, does it even make sense to have that extension with the person?
                 .withExtensions(Maps.ofEntries(
                         entry("redirect_url", "REDIRECT_URL?")));         // Not sure of the usefulness of this?
     }
@@ -92,12 +250,12 @@ public class EventBuilderUtils {
     public static Agent.Builder usingCanvasApplication() {
         return new Agent.Builder()
                 .withId("https://canvas.instructure.com")
-                .withType(CaliperV1Vocab.Actor.SOFTWARE_APPLICATION);
+                .withType(CaliperV1p1Vocab.Entity.SOFTWARE_APPLICATION);
     }
 
     public static Group.Builder usingCourseSectionGroup(Enrollment enrollment) {
         return new Group.Builder()
-                .withType(CaliperV1Vocab.Entity.COURSE_SECTION)
+                .withType(CaliperV1p1Vocab.Entity.COURSE_SECTION)
                 .withId(enrollment.getKlass().getSourcedId())
                 .withExtensions(Maps.ofEntries(
                         entry("context_type", enrollment.getKlass().getTitle())));  // TODO - optional and course title is likely wrong - but where do we find something else useful for it
@@ -106,7 +264,7 @@ public class EventBuilderUtils {
     public static Membership.Builder usingMembership(Enrollment enrollment) {
         return new Membership.Builder()
                 .withId(enrollment.getSourcedId())
-                .withType(CaliperV1Vocab.Entity.MEMBERSHIP)
+                .withType(CaliperV1p1Vocab.Entity.MEMBERSHIP)
                 .withMember(enrollment.getUser().getUserId())              // TODO Redundant - This was intended for a member enrollment ID (if one exists) - perhaps we omit?
                 .withOrganization(enrollment.getKlass().getSourcedId())    // CourseSection
                 .withRoles(Arrays.asList(enrollment.getRole().name()));
@@ -115,23 +273,28 @@ public class EventBuilderUtils {
     public static Event.Builder usingBaseEvent() {
         return new Event.Builder()
                 .withId(UUID.randomUUID().toString())
-                .withObject(usingAccountObject().build())
+                .withContext(CaliperV1p1Vocab.CONTEXT)
                 .withEdApp(usingCanvasApplication().build());
     }
 
     public static Event.Builder usingSessionEventType() {
         return usingBaseEvent()
-                .withType(CaliperV1Vocab.Event.SESSION_EVENT);
-
+                .withObject(usingAccountObject().build())
+                .withType(CaliperV1p1Vocab.Event.SESSION_EVENT);
     }
 
     public static Event.Builder usingLoginEventType() {
         return usingSessionEventType()
-                .withAction(CaliperV1Vocab.Action.LOGGED_IN);
+                .withAction(CaliperV1p1Vocab.Action.LOGGED_IN);
     }
 
     public static Event.Builder usingLogoutEventType() {
         return usingSessionEventType()
-                .withAction(CaliperV1Vocab.Action.LOGGED_OUT);
+                .withAction(CaliperV1p1Vocab.Action.LOGGED_OUT);
+    }
+
+    public static Event.Builder usingMessageEventType() {
+        return usingBaseEvent()
+                .withType(CaliperV1p1Vocab.Event.MESSAGE_EVENT);
     }
 }

--- a/src/main/java/unicon/matthews/dataloader/canvas/io/converter/SupportingEntities.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/io/converter/SupportingEntities.java
@@ -4,8 +4,10 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Singular;
 import unicon.matthews.dataloader.canvas.model.CanvasDataPseudonymDimension;
+import unicon.matthews.dataloader.canvas.model.CanvasDiscussionForumEntryDimension;
 import unicon.matthews.dataloader.canvas.model.CanvasEnrollmentTermDimension;
 import unicon.matthews.dataloader.canvas.model.CanvasPageRequest;
+import unicon.matthews.dataloader.canvas.model.CanvasUserDimension;
 import unicon.matthews.oneroster.Class;
 import unicon.matthews.oneroster.Enrollment;
 import unicon.matthews.oneroster.LineItem;
@@ -22,9 +24,11 @@ public class SupportingEntities {
     Map<String, Class> classes;
     Map<String, User> users;
     Map<String, String> userEmailMap;
+    Collection<CanvasUserDimension> canvasUserDimensions;
     Collection<CanvasDataPseudonymDimension> pseudonymDimensions;
     Map<String, Enrollment> enrollments;
     Map<String, LineItem> lineItems;
     Collection<CanvasPageRequest> pageRequests;
+    Collection<CanvasDiscussionForumEntryDimension> discussionForumEntryDimensions;
 
 }

--- a/src/main/java/unicon/matthews/dataloader/canvas/model/CanvasDiscussionForumEntryDimension.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/model/CanvasDiscussionForumEntryDimension.java
@@ -1,0 +1,70 @@
+package unicon.matthews.dataloader.canvas.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import unicon.matthews.dataloader.canvas.io.deserialize.IsoDateTimeWithOptionalFractionOfSecondDeserializer;
+import unicon.matthews.dataloader.canvas.io.deserialize.NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer;
+import unicon.matthews.dataloader.canvas.io.deserialize.NullableLongFieldDeserializer;
+import unicon.matthews.dataloader.canvas.io.deserialize.ReadableCanvasDumpArtifact;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(suppressConstructorProperties = true)
+@JsonPropertyOrder({ "id", "canvas_id", "message", "workflow_state", "created_at", "updated_at", "deleted_at", "depth" })
+public class CanvasDiscussionForumEntryDimension implements ReadableCanvasDumpArtifact<CanvasDiscussionForumEntryDimension.Types> {
+
+  public enum Types {
+      discussion_entry_dim
+  }
+
+  /**
+   * https://portal.inshosteddata.com/docs#discussion_entry_dim
+   *
+   Columns
+   Name	Type	Description
+   id	bigint	Unique surrogate id for the discussion entry.
+   canvas_id	bigint	Primary key for this record in the Canvas discussion_entries table
+   message	text	Full text of the entry's message
+   workflow_state	varchar	Workflow state for discussion message (values: deleted, active)
+   created_at	timestamp	Timestamp when the discussion entry was created.
+   updated_at	timestamp	Timestamp when the discussion entry was updated.
+   deleted_at	timestamp	Timestamp when the discussion entry was deleted.
+   depth	int	Reply depth for this entry
+   */
+  
+  @JsonProperty("id")
+  private Long id;
+  
+  @JsonProperty("canvas_id")
+  @JsonDeserialize(using = NullableLongFieldDeserializer.class)
+  private Optional<Long> canvasId;
+  
+  @JsonProperty("message")
+  private String message;
+  
+  @JsonProperty("workflow_state")
+  private String workflowState;
+  
+  @JsonProperty("created_at")
+  @JsonDeserialize(using = IsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+  private Instant createdAt;
+  
+  @JsonProperty("updated_at")
+  @JsonDeserialize(using = NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+  private Optional<Instant> updatedAt;
+  
+  @JsonProperty("deleted_at")
+  @JsonDeserialize(using = NullableIsoDateTimeWithOptionalFractionOfSecondDeserializer.class)
+  private Optional<Instant> deletedAt;
+
+  @JsonProperty("depth")
+  private int depth;
+
+}

--- a/src/main/java/unicon/matthews/dataloader/canvas/model/CanvasDiscussionForumEntryFact.java
+++ b/src/main/java/unicon/matthews/dataloader/canvas/model/CanvasDiscussionForumEntryFact.java
@@ -1,0 +1,103 @@
+package unicon.matthews.dataloader.canvas.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import unicon.matthews.dataloader.canvas.io.deserialize.NullableLongFieldDeserializer;
+import unicon.matthews.dataloader.canvas.io.deserialize.ReadableCanvasDumpArtifact;
+
+import java.util.Optional;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(suppressConstructorProperties = true)
+@JsonPropertyOrder({ "discussion_entry_id", "parent_discussion_entry_id", "user_id", "topic_id", "course_id",
+        "enrollment_term_id", "course_account_id", "topic_user_id", "topic_assignment_id", "topic_editor_id",
+        "enrollment_rollup_id", "message_length" })
+public class CanvasDiscussionForumEntryFact implements ReadableCanvasDumpArtifact<CanvasDiscussionForumEntryFact.Types> {
+
+  public enum Types {
+      discussion_entry_fact
+  }
+
+  /**
+   * https://portal.inshosteddata.com/docs#discussion_entry_fact
+   *
+   Measures for discussion entries. Discussion entries are replies in a discussion topic.
+
+   Type: fact
+   Columns
+   Name	Type	Description
+   discussion_entry_id	bigint	Foreign key to this entries attributes.
+   parent_discussion_entry_id	bigint	Foreign key to the reply that it is nested underneath.
+   user_id	bigint	Foreign key to the user that created this entry.
+   topic_id	bigint	Foreign key to associated discussion topic.
+   course_id	bigint	Foreign key to associated course.
+   enrollment_term_id	bigint	Foreign Key to enrollment term table
+   course_account_id	bigint	Foreign key to account for associated course.
+   topic_user_id	bigint	Foreign key to user that posted the associated discussion topic.
+   topic_assignment_id	bigint	Foreign key to assignment associated with the entry's discussion topic.
+   topic_editor_id	bigint	Foreign key to editor associated with the entry's discussion topic.
+   enrollment_rollup_id	bigint	Foreign key to the enrollment roll-up dimension table
+   message_length	int	Length of the message in bytes
+   */
+  
+  @JsonProperty("discussion_entry_id")
+  private Long discussionEntryId;
+
+  /**
+   * This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas documentation does
+   * not state that.
+   */
+  @JsonProperty("parent_discussion_entry_id")
+  @JsonDeserialize(using = NullableLongFieldDeserializer.class)
+  private Optional<Long> parentDiscussionEntryId;
+  
+  @JsonProperty("user_id")
+  private Long userId;
+  
+  @JsonProperty("topic_id")
+  private Long topicId;
+  
+  @JsonProperty("course_id")
+  private Long courseId;
+  
+  @JsonProperty("enrollment_term_id")
+  private Long enrollmentTermId;
+  
+  @JsonProperty("course_account_id")
+  private Long courseAccountId;
+
+  /**
+   * This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas documentation does
+   * not state that.
+   */
+  @JsonProperty("topic_user_id")
+  @JsonDeserialize(using = NullableLongFieldDeserializer.class)
+  private Optional<Long> topicUserId;
+
+  /**
+   * This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas documentation does
+   * not state that.
+   */
+  @JsonProperty("topic_assignment_id")
+  @JsonDeserialize(using = NullableLongFieldDeserializer.class)
+  private Optional<Long> topicAssignmentId;
+
+  /**
+   * This field is actually optional and may be null (data value <em>\N</em>), even though the Canvas documentation does
+   * not state that.
+   */
+  @JsonProperty("topic_editor_id")
+  @JsonDeserialize(using = NullableLongFieldDeserializer.class)
+  private Optional<Long> topicEditorId;
+
+  @JsonProperty("enrollment_rollup_id")
+  private Long enrollmentRollupId;
+
+  @JsonProperty("message_length")
+  private int messageLength;
+}


### PR DESCRIPTION
LAQ-163 Implement the Transform of Canvas Discussion Forum Entry created to IMS Caliper.

This includes adding the CanvasUserDimensions into the SupportingEntities
in order to get the root account ID for the user. This should probably
be rolled into a more comprehensive user model for the purpose of the
transform to reduce collection scanning, but we can do that later.

This also includes the old login scanning and needs to be improved to
leverage the userEmailMap.